### PR TITLE
Auth api controller lifting

### DIFF
--- a/src/backend/auth/auth-manager.ts
+++ b/src/backend/auth/auth-manager.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 import ClientOAuth2 from "client-oauth2";
 import logger from "../logwrapper";
-import { AuthProvider, AuthProviderDefinition } from "./auth";
+import { AuthDetails, AuthProvider, AuthProviderDefinition } from "./auth";
 import { SettingsManager } from "../common/settings-manager";
 import frontendCommunicator from "../common/frontend-communicator";
 import { Notification, app } from "electron";
@@ -124,7 +124,7 @@ class AuthManager extends EventEmitter {
         }
     }
 
-    successfulAuth(providerId: string, tokenData: unknown): void {
+    successfulAuth(providerId: string, tokenData: AuthDetails): void {
         this.emit("auth-success", { providerId: providerId, tokenData: tokenData });
     }
 }


### PR DESCRIPTION
### Description of the Change
Set the types  for the AuthAPIController
The only difficult part is when calling `authManager.successfulAuth(provider.id, tokenData);`
We were splitting the scope chain and reassigning onto an `ClientOAuth2.Data` object, which does not permit this type. 
So I populate an `AuthDetails` object instead with the data available. 
That means `getAuthProvider()` which was previously taking a type `unknown` for the token takes `AuthDetails`, which is more proper either way. 

### Applicable Issues
Lifting the API
